### PR TITLE
browser: option to kill the server when the browser is loaded

### DIFF
--- a/bin/component-test
+++ b/bin/component-test
@@ -41,6 +41,7 @@ program
 program
   .command('browser')
   .description('run tests in the default browser')
+  .option('-k, --kill', 'kill the server after the page loads in the browser')
   .action(browser)
   .unknownOption = noop;
 
@@ -58,9 +59,10 @@ program
   program
     .command(browser)
     .description('run tests in ' + browser)
-    .action(function () {
+    .option('-k, --kill', 'kill the server after the page loads in the browser')
+    .action(function (options) {
       var runner = require(join(runnerdir, 'browser'));
-      runner(browser, done);
+      runner(browser, options, done);
     })
     .unknownOption = noop;
 });
@@ -97,10 +99,10 @@ program.parse(process.argv);
  * Run tests in browser
  */
 
-function browser(name) {
+function browser(name, options) {
   var runner = require(join(runnerdir, 'browser'));
-  if (arguments.length === 1) runner(null, done);
-  else runner(name, done);
+  if (arguments.length === 1) runner(null, name, done);
+  else runner(name, options, done);
 }
 
 /**

--- a/lib/client/mocha.html
+++ b/lib/client/mocha.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="/mocha.css" />
     <link rel="stylesheet" href="/build.css" />
   </head>
-  <body>
+  <body onload="load()">
     <div id="mocha"></div>
     <script src="/mocha.js"></script>
     <script src="/mocha-cloud.js"></script>
@@ -18,6 +18,10 @@
         mochaPhantomJS.run();
       } else {
         cloud(mocha.run());
+      }
+      function load() {
+        var img = new Image();
+        img.src = '/kill.gif';
       }
     </script>
   </body>

--- a/lib/runners/browser.js
+++ b/lib/runners/browser.js
@@ -27,9 +27,9 @@ function normalize(name) {
  * Initialize `run`
  */
 
-function run(name, fn) {
+function run(name, options, fn) {
   // serve the test suite
-  serve(function(err, url) {
+  serve(options, function(err, url) {
     if (err) return fn(err);
     console.log('running tests on: %s', url);
     open(url, normalize(name));

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -44,7 +44,13 @@ $('title').text(title);
  * Expose `serve`
  */
 
-module.exports = function(fn) {
+module.exports = function(options, fn) {
+  if (options.kill) {
+    app.get('/kill.gif', function (req, res, next) {
+      server.close();
+      process.exit();
+    })
+  }
   server.listen(function() {
     var addr = server.address();
     fn(null, 'http://localhost:' + addr.port, server);
@@ -74,10 +80,12 @@ app.get('/mocha.css', function(req, res) {
 });
 
 /**
- * Build the main index file each time
+ * Build the main index file each time.
+ * `app.use()` so it's mounted after the router,
+ * allowing additional routes to be added.
  */
 
-app.get('/*', function(req, res, next) {
+app.use(function(req, res, next) {
   // fetch all the test files
   glob(testglob, function(err, assets) {
     if (err) return next(err);


### PR DESCRIPTION
`-k` or `--kill` option. closes #1

note: you might want to clean up the `runner` api. they are inconsistent now, and i didn't look through it very well. 
