### PR TITLE
Updated misleading wording in travis/saucelabs docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ gem install travis
 Encrypt your credentials:
 
 ```
-travis encrypt SAUCE=username:password -r component/domify
+travis encrypt SAUCE=username:accessKey -r component/domify
 ```
 
 Then add the browsers you want to test. Here's what the [component/domify](http://github.com/component/domify) `.travis.yml` looks like:


### PR DESCRIPTION
- Use "accessKey" instead of "password"

This caused me an hour of pain until I realized it really needed accessKey instead of the user account password.
