### PR TITLE
update mocha-phantomjs and require a working phantomjs version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,14 +23,6 @@ component test browser
 
 Test using [phantomjs](http://phantomjs.org/).
 
-You'll first need to install phantomjs. Using homebrew:
-
-```
-brew install phantomjs
-```
-
-Then you can run the tests:
-
 ```
 component test phantom
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cheerio": "0.12.4",
     "glob": "3.2.7",
     "open": "0.0.4",
-    "mocha-phantomjs": "~3.3.2",
+    "mocha-phantomjs": "^3.6.0",
     "mocha-cloud2": "0.1.0",
     "mocha": "1.15.1",
     "localtunnel": "~0.1.3",
@@ -22,7 +22,8 @@
     "optimist": "~0.6.0",
     "debug": "~0.7.4",
     "yamljs": "~0.1.4",
-    "cross-spawn": "^0.1.7"
+    "cross-spawn": "^0.1.7",
+    "phantomjs": ">=1.9.1 - 1.9.7-15"
   },
   "bin": {
     "component-test": "bin/component-test"


### PR DESCRIPTION
`phantomjs` v2 has been installed in the system path on our build agents and results in tests run with this tool hanging. This PR updates the tool to use a more recent version of `mocha-phantomjs` which uses the version of `phantomjs` installed/required by npm/node, not the version of phantom specified in the path.